### PR TITLE
[CI] Disable `CGO`

### DIFF
--- a/.github/workflows/upload-files-into-s3.yaml
+++ b/.github/workflows/upload-files-into-s3.yaml
@@ -14,7 +14,7 @@ jobs:
           go-version: '1.x'
       - name: Build and zip binary file
         run: |
-          GOOS=linux go build -o bootstrap main.go
+          CGO_ENABLED=0 GOOS=linux go build -o bootstrap main.go
           zip function.zip ./bootstrap
           cp function.zip ./aws
       - name: Upload files into S3 bucket

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ All metrics that were sent from the Lambda function will have the prefix `ping_s
 
 ## Changelog
 **v1.0.3**:
- - Fix cutom resource run logic
+ - Fix custom resource run logic
  - Update `LogzioLambdaExtensionLogs` version 16 -> 18
 
 **v1.0.2**:


### PR DESCRIPTION
## Description 

CI:
- Disable `CGO`, eliminating the dependency on the lambda env glibc version

## What type of PR is this?
#### (check all applicable)
- [ ] 🍕 Feature 
- [ ] 🐛 Bug Fix
- [ ] 🧑‍💻 Code Refactor
- [ ] 🔥 Performance Improvements
- [ ] ✅ Test
- [x] 🤖 Build / CI
- [ ] ⏩ Revert

## Added tests?

- [ ] 👍 yes
- [x] 🙅 no, because they aren't needed
- [ ] 🙋 no, because I need help from somebody
